### PR TITLE
Remove trailing comma in return object

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -184,7 +184,7 @@ function emoji(){}
 				return emoji.replacement(val, null, null, {
 					idx	: idx,
 					actual	: p2,
-					wrapper	: '',
+					wrapper	: ''
 				});
 			}
 			return emoji.replacement(val);


### PR DESCRIPTION
One single trailing comma breaks Google's Closure Compiler